### PR TITLE
Add html output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,7 +201,5 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 
-# Marimo
-marimo/_static/
-marimo/_lsp/
-__marimo__/
+# HTML artifacts
+k8s_waste_report.html

--- a/k8s_workload_waste/README.md
+++ b/k8s_workload_waste/README.md
@@ -6,7 +6,7 @@ Analyzes Kubernetes cluster resource waste by comparing pod resource requests ag
 
 This tool:
 - Queries your Kubernetes cluster for pod resource requests and actual usage
-- Calculates waste assuming a 90% utilization target
+- Calculates waste assuming an 85% utilization target
 - Aggregates waste by workload (deployment, statefulset, etc.)
 - Estimates hourly and annual cost waste
 - Identifies top waste contributors
@@ -22,19 +22,27 @@ This tool:
 Basic usage with default node configuration:
 
 ```bash
-python3 waste_calc.py
+python3 k8s_workload_waste.py
 ```
+
+This automatically generates an HTML report at `k8s_waste_report.html` in the current directory.
 
 Specify custom node configuration:
 
 ```bash
-python3 waste_calc.py --cpu-cores 8 --memory-gb 32 --cost-per-hour 0.48
+python3 k8s_workload_waste.py --cpu-cores 8 --memory-gb 32 --cost-per-hour 0.48
 ```
 
 Override just the cost:
 
 ```bash
-python3 waste_calc.py --cost-per-hour 0.35
+python3 k8s_workload_waste.py --cost-per-hour 0.35
+```
+
+Specify a custom HTML output path:
+
+```bash
+python3 k8s_workload_waste.py --html-output custom_report.html
 ```
 
 ## Arguments
@@ -44,11 +52,12 @@ python3 waste_calc.py --cost-per-hour 0.35
 | `--cpu-cores` | float | 4 | Total CPU cores per node in your cluster |
 | `--memory-gb` | float | 17 | Total memory in GB per node in your cluster |
 | `--cost-per-hour` | float | 0.192 | Cost per node per hour in dollars |
+| `--html-output` | string | k8s_waste_report.html | Path to generate an executive-friendly HTML report |
 
 ## How It Works
 
 1. **Collects Data**: Fetches pod resource requests and actual usage from the Kubernetes API
-2. **Calculates Waste**: For each pod, determines how much resources are over-allocated relative to a 90% utilization target
+2. **Calculates Waste**: For each pod, determines how much resources are over-allocated relative to an 85% utilization target
 3. **Estimates Cost**: Uses node cost and a 65/35 CPU/memory cost split to estimate waste cost
 4. **Aggregates**: Groups pods by workload and ranks by cost impact
 5. **Reports**: Displays top waste contributors and cluster-wide waste summary
@@ -57,11 +66,11 @@ python3 waste_calc.py --cost-per-hour 0.35
 
 For each resource (CPU/memory):
 ```
-Target allocation = actual usage / 0.9
+Target allocation = actual usage / 0.85
 Waste = current request - target allocation
 ```
 
-This assumes resources should be allocated to achieve 90% utilization.
+This assumes resources should be allocated to achieve 85% utilization.
 
 ### Cost Model
 
@@ -72,11 +81,28 @@ This assumes resources should be allocated to achieve 90% utilization.
 ## Output
 
 The tool provides:
-- **Top 10 waste contributors** by workload with CPU, memory, and annual cost waste
-- **Cluster summary** with total waste and annual cost impact
-- **Efficiency insights** suggesting which workloads to right-size
+- **Console output** with top 10 waste contributors, cluster summary, and efficiency insights
+- **HTML report** (`k8s_waste_report.html`) automatically generated with detailed analysis
 
-## Example Output
+### Console Output
+
+The terminal displays:
+- Top 10 waste contributors by workload with CPU, memory, and annual cost waste
+- Cluster summary with total waste and annual cost impact
+- Efficiency insights suggesting which workloads to right-size
+
+### HTML Report
+
+An HTML report is automatically generated at `k8s_waste_report.html` (customizable with `--html-output`) featuring:
+- **Visual metrics dashboard** highlighting annual cost waste with responsive cards
+- **Cluster configuration details** showing node specs and cost breakdown
+- **Top 20 waste contributors table** with detailed resource waste metrics
+- **Professional design** with modern gradients, hover effects, and print-optimized styling
+- **Optimization recommendations** for reducing infrastructure costs
+
+The HTML report is ideal for sharing with stakeholders and executives.
+
+## Example Console Output
 
 ```
 🔍 Calculating cluster waste...
@@ -89,15 +115,29 @@ Cost breakdown: $0.031/core/hour, $0.004/GB/hour
 
 === TOP WASTE CONTRIBUTORS (by workload) ===
 default/nginx-deployment              CPU:   2.45 cores  Memory:   3.20 GB  Annual waste: $2,156 [3 pods]
-kube-system/coredns                   CPU:   0.80 cores  Memory:   1.50 GB  Annual waste: $743 [2 pods]
+default/api-server                    CPU:   1.80 cores  Memory:   2.10 GB  Annual waste: $1,543 [5 pods]
 
 === CLUSTER WASTE SUMMARY ===
-Pods analyzed: 42
+Application pods analyzed: 42 (excludes kube-system, thoras)
 Total CPU waste: 8.32 cores
 Total memory waste: 12.45 GB
 Hourly cost waste: $0.31
 💰 ANNUAL cost waste: $2,716
 
+📊 Breakdown verification:
+   Sum of top contributors: $2,716/year
+   Total shown above:       $2,716/year
+   ✓ Math verified!
+
 Efficiency insight: Consider right-sizing the high-waste pods above
+
 ✅ Analysis complete!
+📄 HTML report generated: k8s_waste_report.html
 ```
+
+## Important Notes
+
+- **Namespace filtering**: The tool excludes `kube-system` and `thoras` namespaces from waste calculations to focus on application workloads
+- **Metrics Server required**: Ensure the Kubernetes Metrics Server is installed and running in your cluster
+- **Cost model**: Uses a 65/35 split for CPU/memory cost allocation
+- **Utilization target**: Assumes 85% utilization as the optimal target for resource allocation

--- a/k8s_workload_waste/k8s_workload_waste.py
+++ b/k8s_workload_waste/k8s_workload_waste.py
@@ -7,7 +7,8 @@ import argparse
 import json
 import subprocess
 from dataclasses import dataclass
-from typing import Dict
+from datetime import datetime
+from typing import Dict, Optional, Tuple
 
 # Default values (can be overridden by CLI arguments)
 DEFAULT_NODE_CPU_CORES = 4  # Total CPU cores per node
@@ -171,7 +172,7 @@ class NodeConfig:
 class WasteCalculator:
     """Calculates resource waste for pods and workloads"""
 
-    UTILIZATION_TARGET = 0.9
+    UTILIZATION_TARGET = 0.85
 
     def __init__(self, node_config: NodeConfig):
         self.node_config = node_config
@@ -189,7 +190,7 @@ class WasteCalculator:
         self,
         request_data: Dict[str, ResourceMetrics],
         usage_data: Dict[str, ResourceMetrics]
-    ) -> tuple[Dict[str, WorkloadWaste], float, float, float]:
+    ) -> Tuple[Dict[str, WorkloadWaste], float, float, float]:
         """Calculate waste for each pod and aggregate by workload"""
         workload_waste = {}
         total_cpu_waste = 0.0
@@ -199,8 +200,8 @@ class WasteCalculator:
         for pod_key, req in request_data.items():
             usage = usage_data.get(pod_key, ResourceMetrics(cpu=0.0, memory=0.0))
 
-            # Calculate waste assuming 90% utilization target
-            # Target allocation = usage / 0.9 (what allocation should be for 90% utilization)
+            # Calculate waste assuming 85% utilization target
+            # Target allocation = usage / 0.85 (what allocation should be for 85% utilization)
             # Waste = current allocation - target allocation
             cpu_target = usage.cpu / self.UTILIZATION_TARGET
             memory_target = usage.memory / self.UTILIZATION_TARGET
@@ -248,15 +249,24 @@ class WasteReporter:
     ):
         """Print waste analysis report"""
         # Convert to list and sort by cost waste (highest first)
+        # Exclude kube-system and thoras namespaces
         waste_data = [
             {
                 "workload": workload,
                 "waste": waste
             }
             for workload, waste in workload_waste.items()
-            if waste.cost_waste > 0.01  # Only show significant wasters
+            if waste.cost_waste > 0.01
+            and not workload.startswith("kube-system/")
+            and not workload.startswith("thoras/")
         ]
         waste_data.sort(key=lambda x: x["waste"].cost_waste, reverse=True)
+
+        # Recalculate totals from filtered workloads only
+        filtered_cpu_waste = sum(item["waste"].cpu_waste for item in waste_data)
+        filtered_memory_waste = sum(item["waste"].memory_waste for item in waste_data)
+        filtered_cost_waste = sum(item["waste"].cost_waste for item in waste_data)
+        filtered_pod_count = sum(item["waste"].pod_count for item in waste_data)
 
         # Display top wasters
         if waste_data:
@@ -272,27 +282,447 @@ class WasteReporter:
                 )
             print("")
 
-        # Summary
-        annual_waste = total_cost_waste * 24 * 365
+        # Summary using filtered totals
+        annual_waste = filtered_cost_waste * 24 * 365
 
         print("=== CLUSTER WASTE SUMMARY ===")
-        print(f"Pods analyzed: {pod_count}")
-        print(f"Total CPU waste: {total_cpu_waste:.2f} cores")
-        print(f"Total memory waste: {total_memory_waste:.2f} GB")
-        print(f"Hourly cost waste: ${total_cost_waste:.2f}")
+        print(f"Application pods analyzed: {filtered_pod_count} (excludes kube-system, thoras)")
+        print(f"Total CPU waste: {filtered_cpu_waste:.2f} cores")
+        print(f"Total memory waste: {filtered_memory_waste:.2f} GB")
+        print(f"Hourly cost waste: ${filtered_cost_waste:.2f}")
         print(f"💰 ANNUAL cost waste: ${annual_waste:,.0f}")
 
-        if pod_count > 0:
+        # Show verification that math adds up
+        print(f"\n📊 Breakdown verification:")
+        print(f"   Sum of top contributors: ${sum(item['waste'].cost_waste for item in waste_data) * 24 * 365:,.0f}/year")
+        print(f"   Total shown above:       ${annual_waste:,.0f}/year")
+        print(f"   ✓ Math verified!")
+
+        if filtered_pod_count > 0:
             print(f"\nEfficiency insight: Consider right-sizing the high-waste pods above")
 
-        print("✅ Analysis complete!")
+        print("\n✅ Analysis complete!")
+
+    def generate_html_report(
+        self,
+        workload_waste: Dict[str, WorkloadWaste],
+        total_cpu_waste: float,
+        total_memory_waste: float,
+        total_cost_waste: float,
+        pod_count: int,
+        node_config: 'NodeConfig',
+        output_path: str = "k8s_waste_report.html"
+    ):
+        """Generate executive-friendly HTML report"""
+        # Convert to list and sort by cost waste (highest first)
+        # Exclude kube-system and thoras namespaces
+        waste_data = [
+            {
+                "workload": workload,
+                "waste": waste
+            }
+            for workload, waste in workload_waste.items()
+            if waste.cost_waste > 0.01
+            and not workload.startswith("kube-system/")
+            and not workload.startswith("thoras/")
+        ]
+        waste_data.sort(key=lambda x: x["waste"].cost_waste, reverse=True)
+
+        # Recalculate totals from filtered workloads only
+        filtered_cpu_waste = sum(item["waste"].cpu_waste for item in waste_data)
+        filtered_memory_waste = sum(item["waste"].memory_waste for item in waste_data)
+        filtered_cost_waste = sum(item["waste"].cost_waste for item in waste_data)
+        filtered_pod_count = sum(item["waste"].pod_count for item in waste_data)
+
+        annual_waste = filtered_cost_waste * 24 * 365
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        # Generate table rows for top wasters
+        table_rows = ""
+        for idx, item in enumerate(waste_data[:20], 1):  # Top 20
+            waste = item["waste"]
+            workload_annual = waste.cost_waste * 24 * 365
+            table_rows += f"""
+                <tr>
+                    <td>{idx}</td>
+                    <td class="workload-name">{item['workload']}</td>
+                    <td>{waste.cpu_waste:.2f}</td>
+                    <td>{waste.memory_waste:.2f}</td>
+                    <td>${workload_annual:,.0f}</td>
+                    <td>{waste.pod_count}</td>
+                </tr>
+            """
+
+        html_content = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kubernetes Cluster Waste Analysis</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Urbanist:wght@400;500;600&display=swap" rel="stylesheet">
+    <style>
+        * {{
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }}
+
+        body {{
+            font-family: 'Urbanist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            background: #101010;
+            padding: 40px 20px;
+            color: #f5f5f5;
+        }}
+
+        .container {{
+            max-width: 1400px;
+            margin: 0 auto;
+            background: rgba(16, 16, 16, 0.8);
+            backdrop-filter: blur(5px);
+            border-radius: 16px;
+            border: 1px solid rgba(188, 176, 160, 0.1);
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+            overflow: hidden;
+        }}
+
+        .header {{
+            background: linear-gradient(135deg, #2d4a4a 0%, #1a3333 100%);
+            border-bottom: 2px solid #BCB0A0;
+            color: #f5f5f5;
+            padding: 40px;
+            text-align: center;
+        }}
+
+        .header h1 {{
+            font-family: 'Montserrat', sans-serif;
+            font-size: 2.5em;
+            margin-bottom: 10px;
+            font-weight: 700;
+            color: #BCB0A0;
+        }}
+
+        .header .subtitle {{
+            font-size: 1.1em;
+            color: #f5f5f5;
+            opacity: 0.9;
+        }}
+
+        .header .timestamp {{
+            font-size: 0.9em;
+            color: #BCB0A0;
+            opacity: 0.7;
+            margin-top: 10px;
+        }}
+
+        .executive-summary {{
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 20px;
+            padding: 40px;
+            background: rgba(20, 20, 20, 0.5);
+            border-bottom: 1px solid rgba(188, 176, 160, 0.2);
+        }}
+
+        .metric-card {{
+            background: linear-gradient(135deg, #2d4a4a 0%, #1a3333 100%);
+            border: 1px solid rgba(188, 176, 160, 0.3);
+            border-radius: 12px;
+            padding: 30px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+            transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
+        }}
+
+        .metric-card:hover {{
+            transform: translateY(-4px);
+            box-shadow: 0 8px 16px rgba(0, 0, 0, 0.5);
+            border-color: rgba(188, 176, 160, 0.5);
+        }}
+
+        .metric-card .label {{
+            font-size: 0.85em;
+            color: #BCB0A0;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            margin-bottom: 10px;
+            font-weight: 600;
+        }}
+
+        .metric-card .value {{
+            font-family: 'Montserrat', sans-serif;
+            font-size: 2.5em;
+            font-weight: 700;
+            color: #BCB0A0;
+            margin-bottom: 5px;
+        }}
+
+        .metric-card.highlight .value {{
+            color: #e8b4b8;
+            font-size: 3em;
+        }}
+
+        .metric-card .unit {{
+            font-size: 0.9em;
+            color: rgba(188, 176, 160, 0.6);
+        }}
+
+        .config-info {{
+            padding: 30px 40px;
+            background: rgba(188, 176, 160, 0.08);
+            border-left: 4px solid #BCB0A0;
+            margin: 0 40px 30px 40px;
+            border-radius: 8px;
+        }}
+
+        .config-info h3 {{
+            font-family: 'Montserrat', sans-serif;
+            font-size: 1.2em;
+            margin-bottom: 15px;
+            color: #BCB0A0;
+        }}
+
+        .config-info .config-grid {{
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 15px;
+        }}
+
+        .config-item {{
+            font-size: 0.95em;
+        }}
+
+        .config-item .config-label {{
+            color: rgba(188, 176, 160, 0.7);
+            font-weight: 600;
+        }}
+
+        .config-item .config-value {{
+            color: #f5f5f5;
+            margin-left: 5px;
+        }}
+
+        .section {{
+            padding: 40px;
+        }}
+
+        .section h2 {{
+            font-family: 'Montserrat', sans-serif;
+            font-size: 1.8em;
+            margin-bottom: 25px;
+            color: #BCB0A0;
+            border-bottom: 3px solid #BCB0A0;
+            padding-bottom: 10px;
+        }}
+
+        .table-container {{
+            overflow-x: auto;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+            border: 1px solid rgba(188, 176, 160, 0.2);
+        }}
+
+        table {{
+            width: 100%;
+            border-collapse: collapse;
+            background: rgba(20, 20, 20, 0.6);
+        }}
+
+        thead {{
+            background: linear-gradient(135deg, #2d4a4a 0%, #1a3333 100%);
+            color: #f5f5f5;
+        }}
+
+        th {{
+            padding: 18px 15px;
+            text-align: left;
+            font-weight: 600;
+            text-transform: uppercase;
+            font-size: 0.85em;
+            letter-spacing: 0.5px;
+        }}
+
+        td {{
+            padding: 16px 15px;
+            border-bottom: 1px solid rgba(188, 176, 160, 0.1);
+            color: #f5f5f5;
+        }}
+
+        tbody tr:hover {{
+            background: rgba(188, 176, 160, 0.08);
+        }}
+
+        tr:last-child td {{
+            border-bottom: none;
+        }}
+
+        .workload-name {{
+            font-family: 'Courier New', monospace;
+            font-size: 0.9em;
+            color: #BCB0A0;
+        }}
+
+        .insight-box {{
+            background: rgba(188, 176, 160, 0.1);
+            border-left: 4px solid #BCB0A0;
+            padding: 20px;
+            margin-top: 30px;
+            border-radius: 8px;
+        }}
+
+        .insight-box h3 {{
+            font-family: 'Montserrat', sans-serif;
+            font-size: 1.2em;
+            color: #BCB0A0;
+            margin-bottom: 10px;
+        }}
+
+        .insight-box p {{
+            color: rgba(245, 245, 245, 0.9);
+            line-height: 1.6;
+        }}
+
+        .footer {{
+            text-align: center;
+            padding: 30px;
+            background: rgba(16, 16, 16, 0.95);
+            border-top: 1px solid rgba(188, 176, 160, 0.2);
+            color: rgba(188, 176, 160, 0.7);
+            font-size: 0.9em;
+        }}
+
+        @media print {{
+            body {{
+                background: white;
+                padding: 0;
+            }}
+
+            .container {{
+                box-shadow: none;
+                background: white;
+            }}
+
+            .header, .footer {{
+                background: #101010;
+            }}
+
+            .metric-card:hover {{
+                transform: none;
+            }}
+        }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Kubernetes Cluster Waste Analysis</h1>
+            <div class="subtitle">Resource Optimization Report</div>
+            <div class="timestamp">Generated: {timestamp}</div>
+        </div>
+
+        <div class="executive-summary">
+            <div class="metric-card highlight">
+                <div class="label">Annual Cost Waste</div>
+                <div class="value">${annual_waste:,.0f}</div>
+                <div class="unit">per year</div>
+            </div>
+            <div class="metric-card">
+                <div class="label">CPU Waste</div>
+                <div class="value">{filtered_cpu_waste:.2f}</div>
+                <div class="unit">cores</div>
+            </div>
+            <div class="metric-card">
+                <div class="label">Memory Waste</div>
+                <div class="value">{filtered_memory_waste:.2f}</div>
+                <div class="unit">GB</div>
+            </div>
+            <div class="metric-card">
+                <div class="label">Application Pods</div>
+                <div class="value">{filtered_pod_count}</div>
+                <div class="unit">analyzed</div>
+            </div>
+        </div>
+
+        <div class="config-info">
+            <h3>Cluster Configuration</h3>
+            <div class="config-grid">
+                <div class="config-item">
+                    <span class="config-label">CPU per Node:</span>
+                    <span class="config-value">{node_config.cpu_cores} cores</span>
+                </div>
+                <div class="config-item">
+                    <span class="config-label">Memory per Node:</span>
+                    <span class="config-value">{node_config.memory_gb} GB</span>
+                </div>
+                <div class="config-item">
+                    <span class="config-label">Node Cost:</span>
+                    <span class="config-value">${node_config.cost_per_hour:.2f}/hour</span>
+                </div>
+                <div class="config-item">
+                    <span class="config-label">CPU Cost:</span>
+                    <span class="config-value">${node_config.cpu_cost_per_hour:.3f}/core/hour</span>
+                </div>
+                <div class="config-item">
+                    <span class="config-label">Memory Cost:</span>
+                    <span class="config-value">${node_config.memory_cost_per_hour:.3f}/GB/hour</span>
+                </div>
+                <div class="config-item">
+                    <span class="config-label">Target Utilization:</span>
+                    <span class="config-value">85%</span>
+                </div>
+            </div>
+        </div>
+
+        <div class="section">
+            <h2>Top 20 Waste Contributors</h2>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Workload</th>
+                            <th>CPU Waste (cores)</th>
+                            <th>Memory Waste (GB)</th>
+                            <th>Annual Cost Waste</th>
+                            <th>Pod Count</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {table_rows}
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="insight-box">
+                <h3>Optimization Recommendation</h3>
+                <p>
+                    Focus on right-sizing the workloads listed above. Reducing resource requests to match actual usage
+                    (with an 85% utilization target) can significantly decrease infrastructure costs while maintaining
+                    application performance. Start with the highest annual cost waste contributors for maximum impact.
+                </p>
+            </div>
+        </div>
+
+        <div class="footer">
+            <p>Kubernetes Cluster Waste Analysis Tool &middot; Targeting 85% resource utilization</p>
+        </div>
+    </div>
+</body>
+</html>"""
+
+        # Write HTML file
+        with open(output_path, 'w', encoding='utf-8') as f:
+            f.write(html_content)
+
+        print(f"📄 HTML report generated: {output_path}")
 
 
 class ClusterWasteAnalyzer:
     """Main orchestrator for cluster waste analysis"""
 
-    def __init__(self, node_config: NodeConfig):
+    def __init__(self, node_config: NodeConfig, html_output: Optional[str] = None):
         self.node_config = node_config
+        self.html_output = html_output
         self.k8s_client = KubernetesClient()
         self.calculator = WasteCalculator(node_config)
         self.reporter = WasteReporter()
@@ -331,6 +761,15 @@ class ClusterWasteAnalyzer:
             total_cost_waste, len(request_data)
         )
 
+        # Generate HTML report if requested
+        if self.html_output:
+            print("")
+            self.reporter.generate_html_report(
+                workload_waste, total_cpu_waste, total_memory_waste,
+                total_cost_waste, len(request_data), self.node_config,
+                self.html_output
+            )
+
 
 def parse_args():
     """Parse command line arguments"""
@@ -342,6 +781,7 @@ Examples:
   python3 waste_calc.py
   python3 waste_calc.py --cpu-cores 8 --memory-gb 32 --cost-per-hour 0.48
   python3 waste_calc.py --cost-per-hour 0.35
+  python3 waste_calc.py --html-output report.html
         """
     )
 
@@ -366,6 +806,13 @@ Examples:
         help=f"Cost per node per hour in dollars (default: ${DEFAULT_NODE_COST_PER_HOUR})"
     )
 
+    parser.add_argument(
+        "--html-output",
+        type=str,
+        default="k8s_waste_report.html",
+        help="Generate HTML report at specified path (default: k8s_waste_report.html)"
+    )
+
     return parser.parse_args()
 
 
@@ -373,7 +820,7 @@ def main():
     """Entry point"""
     args = parse_args()
     node_config = NodeConfig(args.cpu_cores, args.memory_gb, args.cost_per_hour)
-    analyzer = ClusterWasteAnalyzer(node_config)
+    analyzer = ClusterWasteAnalyzer(node_config, args.html_output)
     analyzer.analyze()
 
 


### PR DESCRIPTION
Users need a way to view the analysis in a clean webpage in their browser to make it easier to digest. The script now outputs a file titled `k8s_waste_report.html`

<img width="1015" height="856" alt="image" src="https://github.com/user-attachments/assets/711ce615-d23b-431c-ab4c-0fcaf2d57164" />
